### PR TITLE
Add Google Cloud Run authentication to API clients

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ javafx {
 }
 
 dependencies {
+    implementation('com.google.auth:google-auth-library-oauth2-http:1.23.0')
     implementation('org.slf4j:slf4j-api:2.0.9')
     implementation('ch.qos.logback:logback-classic:1.4.14')
     implementation("org.apache.commons:commons-lang3:3.18.0")

--- a/src/main/java/com/palmer/billingstatementgenerator/client/ApiConfig.java
+++ b/src/main/java/com/palmer/billingstatementgenerator/client/ApiConfig.java
@@ -1,5 +1,7 @@
 package com.palmer.billingstatementgenerator.client;
 
+import com.google.auth.oauth2.IdTokenCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -7,7 +9,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.net.URI;
 import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
 import java.util.Properties;
 
 public class ApiConfig {
@@ -17,6 +21,7 @@ public class ApiConfig {
     private static final String CONFIG_PATH = CONFIG_DIR + "/api.properties";
     private static String baseUrl;
     private static HttpClient httpClient;
+    private static IdTokenCredentials idTokenCredentials;
 
     private ApiConfig() {
     }
@@ -41,6 +46,20 @@ public class ApiConfig {
             baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
         }
 
+        String serviceAccountKey = config.getProperty("api.service-account-key", "").trim();
+        if (!serviceAccountKey.isEmpty()) {
+            try (FileInputStream keyStream = new FileInputStream(serviceAccountKey)) {
+                ServiceAccountCredentials serviceAccountCreds = ServiceAccountCredentials.fromStream(keyStream);
+                idTokenCredentials = IdTokenCredentials.newBuilder()
+                        .setIdTokenProvider(serviceAccountCreds)
+                        .setTargetAudience(baseUrl)
+                        .build();
+            } catch (IOException e) {
+                log.error("Failed to load service account key from {}", serviceAccountKey, e);
+                throw new IllegalStateException("Failed to load service account key from " + serviceAccountKey, e);
+            }
+        }
+
         httpClient = HttpClient.newHttpClient();
 
         log.info("API configured - base URL: {}", baseUrl);
@@ -51,11 +70,11 @@ public class ApiConfig {
     }
 
     public static String getCatalogUrl() {
-        return baseUrl + "/catalog";
+        return getBaseUrl() + "/catalog";
     }
 
     public static String getStatementsUrl() {
-        return baseUrl + "/statements";
+        return getBaseUrl() + "/statements";
     }
 
     public static HttpClient getHttpClient() {
@@ -65,6 +84,15 @@ public class ApiConfig {
         }
 
         return httpClient;
+    }
+
+    public static HttpRequest.Builder authenticatedRequest(URI uri) throws IOException {
+        if (idTokenCredentials == null) {
+            return HttpRequest.newBuilder(uri);
+        }
+
+        return HttpRequest.newBuilder(uri)
+                .header("Authorization", idTokenCredentials.getRequestMetadata(uri).get("Authorization").getFirst());
     }
 
     private static Properties loadConfig() {
@@ -87,6 +115,7 @@ public class ApiConfig {
     private static void writeConfigTemplate(File configFile) {
         try (FileWriter w = new FileWriter(configFile)) {
             w.write("api.base-url=http://localhost:18080\n");
+            w.write("# api.service-account-key=/path/to/service-account.json\n");
         } catch (IOException e) {
             log.warn("Could not write config template to {}", CONFIG_PATH, e);
         }

--- a/src/main/java/com/palmer/billingstatementgenerator/client/CatalogClient.java
+++ b/src/main/java/com/palmer/billingstatementgenerator/client/CatalogClient.java
@@ -154,8 +154,7 @@ public class CatalogClient {
     }
 
     private static HttpResponse<String> getResponse(String endPoint) throws IOException, InterruptedException {
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(ApiConfig.getCatalogUrl() + endPoint))
+        HttpRequest request = ApiConfig.authenticatedRequest(URI.create(ApiConfig.getCatalogUrl() + endPoint))
                 .GET()
                 .build();
 

--- a/src/main/java/com/palmer/billingstatementgenerator/client/StatementClient.java
+++ b/src/main/java/com/palmer/billingstatementgenerator/client/StatementClient.java
@@ -109,8 +109,7 @@ public class StatementClient {
         ObjectNode body = buildStatementBody(statement);
 
         try {
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(ApiConfig.getStatementsUrl()))
+            HttpRequest request = ApiConfig.authenticatedRequest(URI.create(ApiConfig.getStatementsUrl()))
                     .header("Content-Type", "application/json")
                     .POST(HttpRequest.BodyPublishers.ofString(body.toString()))
                     .build();
@@ -129,8 +128,7 @@ public class StatementClient {
         ObjectNode body = buildStatementBody(statement);
 
         try {
-            HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(ApiConfig.getStatementsUrl() + "/" + id))
+            HttpRequest request = ApiConfig.authenticatedRequest(URI.create(ApiConfig.getStatementsUrl() + "/" + id))
                 .header("Content-Type", "application/json")
                 .PUT(HttpRequest.BodyPublishers.ofString(body.toString()))
                 .build();
@@ -144,8 +142,7 @@ public class StatementClient {
 
     public PdfResult getPdf(int id) {
         try {
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(ApiConfig.getStatementsUrl() + String.format("/%d/pdf", id)))
+            HttpRequest request = ApiConfig.authenticatedRequest(URI.create(ApiConfig.getStatementsUrl() + String.format("/%d/pdf", id)))
                     .GET()
                     .build();
 
@@ -300,8 +297,7 @@ public class StatementClient {
     private static HttpResponse<String> getResponse(String... endPoints) throws IOException, InterruptedException {
         String statementsUrl = ApiConfig.getStatementsUrl();
 
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(endPoints.length > 0 ? statementsUrl + endPoints[0] : statementsUrl))
+        HttpRequest request = ApiConfig.authenticatedRequest(URI.create(endPoints.length > 0 ? statementsUrl + endPoints[0] : statementsUrl))
                 .GET()
                 .build();
 


### PR DESCRIPTION
Summary

  - Added google-auth-library-oauth2-http dependency to support service account authentication
  - Updated ApiConfig to optionally load a service account key from api.properties and generate Cloud Run ID tokens
  - Added authenticatedRequest() helper that attaches the Authorization header when credentials are configured, falls back to unauthenticated for local
  development
  - Updated CatalogClient and StatementClient to use authenticatedRequest() across all GET, POST, and PUT calls
