### PR TITLE
Apply Windows 11 and Windows 10 native window effects (#74)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,7 @@ dependencies {
     implementation('ch.qos.logback:logback-classic:1.4.14')
     implementation('com.fasterxml.jackson.core:jackson-databind:2.17.3')
     implementation('com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.3')
+    implementation('net.java.dev.jna:jna-platform:5.14.0')
     implementation('org.kordamp.ikonli:ikonli-javafx:12.3.1')
     implementation('org.kordamp.ikonli:ikonli-fontawesome5-pack:12.3.1')
 

--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,7 @@ run {
         jvmArgs "-Xdock:icon=${projectDir}/packaging/app.icns",
                 '-Xdock:name=Statement Manager'
     }
+    jvmArgs '--add-opens=javafx.graphics/com.sun.glass.ui=ALL-UNNAMED'
 }
 
 tasks.register('jpackageApp', Exec) {

--- a/src/main/java/com/palmer/billingstatementgenerator/MainApp.java
+++ b/src/main/java/com/palmer/billingstatementgenerator/MainApp.java
@@ -21,6 +21,7 @@ import javafx.scene.layout.BorderPane;
 import javafx.scene.text.Font;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
+import javafx.stage.Window;
 import javafx.util.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -110,6 +111,7 @@ public class MainApp extends Application {
             mainStage.setTitle("Statement Manager");
             mainStage.getIcons().addAll(primaryStage.getIcons());
             mainStage.show();
+            WindowsEffects.apply(mainStage);
 
             mainView.wireKeyNav(mainScene);
             mainView.setEventTracker(new WorkflowEventTracker(mainStage, mainView.getTabPane()));

--- a/src/main/java/com/palmer/billingstatementgenerator/MainApp.java
+++ b/src/main/java/com/palmer/billingstatementgenerator/MainApp.java
@@ -38,6 +38,7 @@ public class MainApp extends Application {
 
     @Override
     public void start(Stage primaryStage) throws Exception {
+        WindowsEffects.init();
         log.info("Application starting");
         if (!AppLock.acquire()) {
             new MessageDialog("Already Running",
@@ -111,7 +112,7 @@ public class MainApp extends Application {
             mainStage.setTitle("Statement Manager");
             mainStage.getIcons().addAll(primaryStage.getIcons());
             mainStage.show();
-            WindowsEffects.apply(mainStage);
+            Platform.runLater(() -> WindowsEffects.apply(mainStage));
 
             mainView.wireKeyNav(mainScene);
             mainView.setEventTracker(new WorkflowEventTracker(mainStage, mainView.getTabPane()));

--- a/src/main/java/com/palmer/billingstatementgenerator/WindowsEffects.java
+++ b/src/main/java/com/palmer/billingstatementgenerator/WindowsEffects.java
@@ -1,8 +1,7 @@
 package com.palmer.billingstatementgenerator;
 
-import com.sun.jna.Native;
-import com.sun.jna.Pointer;
-import com.sun.jna.Structure;
+import com.sun.glass.ui.Window;
+import com.sun.jna.*;
 import com.sun.jna.platform.win32.User32;
 import com.sun.jna.platform.win32.WinDef;
 import com.sun.jna.ptr.IntByReference;
@@ -18,23 +17,31 @@ public final class WindowsEffects {
     private static final int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
     private static final int DWMWA_WINDOW_CORNER_PREFERENCE = 33;
     private static final int DWMWCP_ROUND = 2;
+    private static final int DWMWA_SYSTEMBACKDROP_TYPE = 38;
+    private static final int DWMSBT_MAINWINDOW = 2; // Mica
 
     private WindowsEffects() {
     }
 
     public static void apply(Stage stage) {
         if (!isWindows()) {
+            log.debug("Not Windows, skipping effects");
             return;
         }
         try {
-            WinDef.HWND hwnd = User32.INSTANCE.FindWindow(null, stage.getTitle());
+            WinDef.HWND hwnd = getHwnd(stage);
+            log.debug("FindWindow result for '{}': {}", stage.getTitle(), hwnd);
             if (hwnd == null) {
                 return;
             }
             if (isWindows11()) {
+                enableDarkMode(hwnd);
                 setIntAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, 1);
                 setIntAttribute(hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, DWMWCP_ROUND);
-            } else {
+                setIntAttribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE, DWMSBT_MAINWINDOW);
+            }
+            else {
+                log.debug("Applying Windows 10 effects");
                 applyWindows10(hwnd);
             }
         } catch (Exception e) {
@@ -42,9 +49,39 @@ public final class WindowsEffects {
         }
     }
 
+    private static WinDef.HWND getHwnd(Stage stage) {
+        for (Window w : Window.getWindows()) {
+            if (stage.getTitle().equals(w.getTitle())) {
+                long handle = w.getNativeHandle();
+                log.debug("Glass HWND for '{}': 0x{}", stage.getTitle(), Long.toHexString(handle));
+                return new WinDef.HWND(Pointer.createConstant(handle));
+            }
+        }
+        log.debug("Glass HWND not found for '{}'", stage.getTitle());
+        return null;
+    }
+
     private static void setIntAttribute(WinDef.HWND hwnd, int attribute, int value) {
         IntByReference ref = new IntByReference(value);
-        Dwmapi.INSTANCE.DwmSetWindowAttribute(hwnd, attribute, ref.getPointer(), 4);
+        int result = Dwmapi.INSTANCE.DwmSetWindowAttribute(hwnd, attribute, ref.getPointer(), 4);
+        log.debug("DwmSetWindowAttribute attr={} value={} result=0x{}", attribute, value, Integer.toHexString(result));
+    }
+
+    private static void enableDarkMode(WinDef.HWND hwnd) {
+        try {
+            WinDef.HMODULE hMod = Kernel32Ex.INSTANCE.GetModuleHandleA("uxtheme");
+            Pointer setPreferredAppMode = Kernel32Ex.INSTANCE.GetProcAddress(hMod, Pointer.createConstant(135));
+            Pointer allowDarkModeForWindow = Kernel32Ex.INSTANCE.GetProcAddress(hMod, Pointer.createConstant(133));
+
+            if (setPreferredAppMode != null) {
+                Function.getFunction(setPreferredAppMode, Function.ALT_CONVENTION).invoke(new Object[]{2});
+            }
+            if (allowDarkModeForWindow != null) {
+                Function.getFunction(allowDarkModeForWindow, Function.ALT_CONVENTION).invoke(new Object[]{hwnd, true});
+            }
+        } catch (Exception e) {
+            log.warn("Failed to enable dark mode via uxtheme", e);
+        }
     }
 
     private static void applyWindows10(WinDef.HWND hwnd) {
@@ -68,6 +105,7 @@ public final class WindowsEffects {
         if (!isWindows()) {
             return false;
         }
+
         try {
             Process process = Runtime.getRuntime().exec(
                     new String[]{"reg", "query",
@@ -77,6 +115,7 @@ public final class WindowsEffects {
             String output = new String(process.getInputStream().readAllBytes());
             String[] parts = output.trim().split("\\s+");
             int build = Integer.parseInt(parts[parts.length - 1]);
+            log.debug("Windows build number: {}", build);
             return build >= 22000;
         } catch (Exception e) {
             return false;
@@ -87,8 +126,31 @@ public final class WindowsEffects {
         return System.getProperty("os.name", "").toLowerCase().contains("windows");
     }
 
+    public static void init() {
+        if (!isWindows()) {
+            return;
+        }
+
+        try {
+            WinDef.HMODULE hMod = Kernel32Ex.INSTANCE.GetModuleHandleA("uxtheme");
+            log.debug("uxtheme module: {}", hMod);
+            Pointer fn = Kernel32Ex.INSTANCE.GetProcAddress(hMod, Pointer.createConstant(135));
+            log.debug("SetPreferredAppMode ptr: {}", fn);
+            if (fn != null) {
+                Function.getFunction(fn, Function.ALT_CONVENTION).invoke(new Object[]{2});
+                log.debug("SetPreferredAppMode called successfully");
+            } else {
+                log.warn("SetPreferredAppMode not found at ordinal 135");
+            }
+        } catch (Exception e) {
+            log.warn("Failed to init dark mode", e);
+        }
+    }
+
     private interface Dwmapi extends StdCallLibrary {
         Dwmapi INSTANCE = Native.load("dwmapi", Dwmapi.class);
+
+        int DwmGetWindowAttribute(WinDef.HWND hwnd, int dwAttribute, Pointer pvAttribute, int cbAttribute);
 
         int DwmSetWindowAttribute(WinDef.HWND hwnd, int dwAttribute, Pointer pvAttribute, int cbAttribute);
     }
@@ -97,6 +159,12 @@ public final class WindowsEffects {
         User32Ex INSTANCE = Native.load("user32", User32Ex.class);
 
         boolean SetWindowCompositionAttribute(WinDef.HWND hwnd, WindowCompositionAttributeData data);
+    }
+
+    private interface Kernel32Ex extends StdCallLibrary {
+        Kernel32Ex INSTANCE = Native.load("kernel32", Kernel32Ex.class);
+        WinDef.HMODULE GetModuleHandleA(String moduleName);
+        Pointer GetProcAddress(WinDef.HMODULE hModule, Pointer procName);
     }
 
     @Structure.FieldOrder({"Attribute", "Data", "SizeOfData"})

--- a/src/main/java/com/palmer/billingstatementgenerator/WindowsEffects.java
+++ b/src/main/java/com/palmer/billingstatementgenerator/WindowsEffects.java
@@ -1,8 +1,10 @@
 package com.palmer.billingstatementgenerator;
 
 import com.sun.glass.ui.Window;
-import com.sun.jna.*;
-import com.sun.jna.platform.win32.User32;
+import com.sun.jna.Function;
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.Structure;
 import com.sun.jna.platform.win32.WinDef;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.win32.StdCallLibrary;
@@ -17,30 +19,26 @@ public final class WindowsEffects {
     private static final int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
     private static final int DWMWA_WINDOW_CORNER_PREFERENCE = 33;
     private static final int DWMWCP_ROUND = 2;
-    private static final int DWMWA_SYSTEMBACKDROP_TYPE = 38;
-    private static final int DWMSBT_MAINWINDOW = 2; // Mica
 
     private WindowsEffects() {
     }
 
     public static void apply(Stage stage) {
         if (!isWindows()) {
-            log.debug("Not Windows, skipping effects");
             return;
         }
+
         try {
             WinDef.HWND hwnd = getHwnd(stage);
-            log.debug("FindWindow result for '{}': {}", stage.getTitle(), hwnd);
             if (hwnd == null) {
                 return;
             }
             if (isWindows11()) {
+                log.debug("Applying Windows 11 effects");
                 enableDarkMode(hwnd);
                 setIntAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, 1);
                 setIntAttribute(hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, DWMWCP_ROUND);
-                setIntAttribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE, DWMSBT_MAINWINDOW);
-            }
-            else {
+            } else {
                 log.debug("Applying Windows 10 effects");
                 applyWindows10(hwnd);
             }
@@ -50,32 +48,22 @@ public final class WindowsEffects {
     }
 
     private static WinDef.HWND getHwnd(Stage stage) {
-        for (Window w : Window.getWindows()) {
-            if (stage.getTitle().equals(w.getTitle())) {
-                long handle = w.getNativeHandle();
-                log.debug("Glass HWND for '{}': 0x{}", stage.getTitle(), Long.toHexString(handle));
-                return new WinDef.HWND(Pointer.createConstant(handle));
-            }
-        }
-        log.debug("Glass HWND not found for '{}'", stage.getTitle());
-        return null;
+        return Window.getWindows().stream()
+                     .filter(w -> stage.getTitle().equals(w.getTitle()))
+                     .map(w -> new WinDef.HWND(Pointer.createConstant(w.getNativeHandle())))
+                     .findFirst().orElse(null);
     }
 
     private static void setIntAttribute(WinDef.HWND hwnd, int attribute, int value) {
         IntByReference ref = new IntByReference(value);
-        int result = Dwmapi.INSTANCE.DwmSetWindowAttribute(hwnd, attribute, ref.getPointer(), 4);
-        log.debug("DwmSetWindowAttribute attr={} value={} result=0x{}", attribute, value, Integer.toHexString(result));
+        Dwmapi.INSTANCE.DwmSetWindowAttribute(hwnd, attribute, ref.getPointer(), 4);
     }
 
     private static void enableDarkMode(WinDef.HWND hwnd) {
         try {
             WinDef.HMODULE hMod = Kernel32Ex.INSTANCE.GetModuleHandleA("uxtheme");
-            Pointer setPreferredAppMode = Kernel32Ex.INSTANCE.GetProcAddress(hMod, Pointer.createConstant(135));
             Pointer allowDarkModeForWindow = Kernel32Ex.INSTANCE.GetProcAddress(hMod, Pointer.createConstant(133));
 
-            if (setPreferredAppMode != null) {
-                Function.getFunction(setPreferredAppMode, Function.ALT_CONVENTION).invoke(new Object[]{2});
-            }
             if (allowDarkModeForWindow != null) {
                 Function.getFunction(allowDarkModeForWindow, Function.ALT_CONVENTION).invoke(new Object[]{hwnd, true});
             }
@@ -115,7 +103,6 @@ public final class WindowsEffects {
             String output = new String(process.getInputStream().readAllBytes());
             String[] parts = output.trim().split("\\s+");
             int build = Integer.parseInt(parts[parts.length - 1]);
-            log.debug("Windows build number: {}", build);
             return build >= 22000;
         } catch (Exception e) {
             return false;
@@ -133,14 +120,10 @@ public final class WindowsEffects {
 
         try {
             WinDef.HMODULE hMod = Kernel32Ex.INSTANCE.GetModuleHandleA("uxtheme");
-            log.debug("uxtheme module: {}", hMod);
             Pointer fn = Kernel32Ex.INSTANCE.GetProcAddress(hMod, Pointer.createConstant(135));
-            log.debug("SetPreferredAppMode ptr: {}", fn);
+
             if (fn != null) {
                 Function.getFunction(fn, Function.ALT_CONVENTION).invoke(new Object[]{2});
-                log.debug("SetPreferredAppMode called successfully");
-            } else {
-                log.warn("SetPreferredAppMode not found at ordinal 135");
             }
         } catch (Exception e) {
             log.warn("Failed to init dark mode", e);
@@ -149,8 +132,6 @@ public final class WindowsEffects {
 
     private interface Dwmapi extends StdCallLibrary {
         Dwmapi INSTANCE = Native.load("dwmapi", Dwmapi.class);
-
-        int DwmGetWindowAttribute(WinDef.HWND hwnd, int dwAttribute, Pointer pvAttribute, int cbAttribute);
 
         int DwmSetWindowAttribute(WinDef.HWND hwnd, int dwAttribute, Pointer pvAttribute, int cbAttribute);
     }
@@ -163,7 +144,9 @@ public final class WindowsEffects {
 
     private interface Kernel32Ex extends StdCallLibrary {
         Kernel32Ex INSTANCE = Native.load("kernel32", Kernel32Ex.class);
+
         WinDef.HMODULE GetModuleHandleA(String moduleName);
+
         Pointer GetProcAddress(WinDef.HMODULE hModule, Pointer procName);
     }
 
@@ -179,6 +162,5 @@ public final class WindowsEffects {
         public int AccentState;
         public int AccentFlags;
         public int GradientColor;
-        public int AnimationId;
     }
 }

--- a/src/main/java/com/palmer/billingstatementgenerator/WindowsEffects.java
+++ b/src/main/java/com/palmer/billingstatementgenerator/WindowsEffects.java
@@ -1,0 +1,116 @@
+package com.palmer.billingstatementgenerator;
+
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.Structure;
+import com.sun.jna.platform.win32.User32;
+import com.sun.jna.platform.win32.WinDef;
+import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.win32.StdCallLibrary;
+import javafx.stage.Stage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class WindowsEffects {
+
+    private static final Logger log = LoggerFactory.getLogger(WindowsEffects.class);
+
+    private static final int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
+    private static final int DWMWA_WINDOW_CORNER_PREFERENCE = 33;
+    private static final int DWMWCP_ROUND = 2;
+
+    private WindowsEffects() {
+    }
+
+    public static void apply(Stage stage) {
+        if (!isWindows()) {
+            return;
+        }
+        try {
+            WinDef.HWND hwnd = User32.INSTANCE.FindWindow(null, stage.getTitle());
+            if (hwnd == null) {
+                return;
+            }
+            if (isWindows11()) {
+                setIntAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, 1);
+                setIntAttribute(hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, DWMWCP_ROUND);
+            } else {
+                applyWindows10(hwnd);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to apply Windows effects", e);
+        }
+    }
+
+    private static void setIntAttribute(WinDef.HWND hwnd, int attribute, int value) {
+        IntByReference ref = new IntByReference(value);
+        Dwmapi.INSTANCE.DwmSetWindowAttribute(hwnd, attribute, ref.getPointer(), 4);
+    }
+
+    private static void applyWindows10(WinDef.HWND hwnd) {
+        // ACCENT_ENABLE_ACRYLICBLURBEHIND = 4
+        // Available on Windows 10 1903+
+        AccentPolicy accent = new AccentPolicy();
+        accent.AccentState = 4;
+        accent.AccentFlags = 2;
+        accent.GradientColor = 0x00000000;
+        accent.write();
+
+        WindowCompositionAttributeData data = new WindowCompositionAttributeData();
+        data.Attribute = 19; // WCA_ACCENT_POLICY
+        data.Data = accent.getPointer();
+        data.SizeOfData = accent.size();
+
+        User32Ex.INSTANCE.SetWindowCompositionAttribute(hwnd, data);
+    }
+
+    private static boolean isWindows11() {
+        if (!isWindows()) {
+            return false;
+        }
+        try {
+            Process process = Runtime.getRuntime().exec(
+                    new String[]{"reg", "query",
+                            "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
+                            "/v", "CurrentBuildNumber"}
+            );
+            String output = new String(process.getInputStream().readAllBytes());
+            String[] parts = output.trim().split("\\s+");
+            int build = Integer.parseInt(parts[parts.length - 1]);
+            return build >= 22000;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static boolean isWindows() {
+        return System.getProperty("os.name", "").toLowerCase().contains("windows");
+    }
+
+    private interface Dwmapi extends StdCallLibrary {
+        Dwmapi INSTANCE = Native.load("dwmapi", Dwmapi.class);
+
+        int DwmSetWindowAttribute(WinDef.HWND hwnd, int dwAttribute, Pointer pvAttribute, int cbAttribute);
+    }
+
+    private interface User32Ex extends StdCallLibrary {
+        User32Ex INSTANCE = Native.load("user32", User32Ex.class);
+
+        boolean SetWindowCompositionAttribute(WinDef.HWND hwnd, WindowCompositionAttributeData data);
+    }
+
+    @Structure.FieldOrder({"Attribute", "Data", "SizeOfData"})
+    public static class WindowCompositionAttributeData extends Structure {
+        public int Attribute;
+        public Pointer Data;
+        public int SizeOfData;
+    }
+
+    @Structure.FieldOrder({"AccentState", "AccentFlags", "GradientColor", "AnimationId"})
+    public static class AccentPolicy extends Structure {
+        public int AccentState;
+        public int AccentFlags;
+        public int GradientColor;
+        public int AnimationId;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `WindowsEffects` utility class using JNA to apply platform-native window styling on Windows
- Windows 11: dark title bar via `DWMWA_USE_IMMERSIVE_DARK_MODE` and rounded corners via `DWMWA_WINDOW_CORNER_PREFERENCE`, with dark mode pre-enabled via uxtheme `etPreferredAppMode before any window is created`SetPreferredAppMode` before any window is created
- Windows 10 (1903+): acrylic blur-behind via `SetWindowCompositionAttribute` with `ACCENT_ENABLE_ACRYLICBLURBEHIND`
- Silent no-op on macOS and unsupported Windows versions — fails gracefully with a warn log if any native call throws
- Adds `jna-platform` dependency

Closes #74

## Commits
- **Add decoration for windows**
- **Work done for Windows 11 styling**
- **Cleanup WindowsEffects.java**
