### PR TITLE
Implement AtlantaFX redesign with side navigation (#21)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,6 @@ def resolveQualifier = {
 ext {
     junitVersion = '5.7.1'
     spockVersion = '2.3-groovy-4.0'
-    appVersionBase = '1.1.0'
     appVersionQualifier = resolveQualifier()
     appVersion = appVersionQualifier ? "${appVersionBase}-${appVersionQualifier}" : appVersionBase
 }
@@ -81,6 +80,7 @@ javafx {
 }
 
 dependencies {
+    implementation('io.github.mkpaz:atlantafx-base:2.0.1')
     implementation('org.slf4j:slf4j-api:2.0.9')
     implementation('ch.qos.logback:logback-classic:1.4.14')
     implementation('com.fasterxml.jackson.core:jackson-databind:2.17.3')
@@ -124,9 +124,9 @@ tasks.register('jpackageApp', Exec) {
     def args = [
             'jpackage',
             '--type', os.macOsX ? 'dmg' : (os.windows ? 'msi' : 'deb'),
-            '--name', 'Statement Manager',
+            '--name', 'Eternatel',
             '--app-version', appVersionBase,
-            '--vendor', 'Statement Manager',
+            '--vendor', 'Eternatel',
             '--icon', iconFile,
             '--input', libDir.absolutePath,
             '--main-jar', "${rootProject.name}-${project.version}.jar",
@@ -141,14 +141,14 @@ tasks.register('jpackageApp', Exec) {
             def ext = os.macOsX ? 'dmg' : (os.windows ? 'msi' : 'deb')
             def found = outputDir.listFiles()?.find { it.name.endsWith(".${ext}") }
             if (found) {
-                found.renameTo(new File(outputDir, "Statement Manager-${appVersion}.${ext}"))
+                found.renameTo(new File(outputDir, "Eternatel-${appVersion}.${ext}"))
             }
         }
     }
 }
 
 javadoc {
-    title = 'Statement Manager'
+    title = 'Eternatel'
     options.encoding = 'UTF-8'
     options.memberLevel = JavadocMemberLevel.PROTECTED
     options.addStringOption('Xdoclint:none', '-quiet')

--- a/src/main/java/com/palmer/billingstatementgenerator/MainApp.java
+++ b/src/main/java/com/palmer/billingstatementgenerator/MainApp.java
@@ -1,5 +1,7 @@
 package com.palmer.billingstatementgenerator;
 
+import atlantafx.base.theme.PrimerDark;
+import atlantafx.base.theme.PrimerLight;
 import com.palmer.billingstatementgenerator.client.ApiConfig;
 import com.palmer.billingstatementgenerator.client.VersionClient;
 import com.palmer.billingstatementgenerator.logging.WorkflowEventTracker;
@@ -42,11 +44,14 @@ public class MainApp extends Application {
         log.info("Application starting");
         if (!AppLock.acquire()) {
             new MessageDialog("Already Running",
-                    "Statement Manager is already open.\n" +
+                    "Eternatel is already open.\n" +
                     "Only one instance can run at a time.").open();
             Platform.exit();
             return;
         }
+
+        Application.setUserAgentStylesheet(new PrimerLight().getUserAgentStylesheet());
+
         loadFonts();
 
         var iconStream = getClass().getResourceAsStream(
@@ -109,7 +114,7 @@ public class MainApp extends Application {
 
             Stage mainStage = new Stage();
             mainStage.setScene(mainScene);
-            mainStage.setTitle("Statement Manager");
+            mainStage.setTitle("Eternatel");
             mainStage.getIcons().addAll(primaryStage.getIcons());
             mainStage.show();
             Platform.runLater(() -> WindowsEffects.apply(mainStage));

--- a/src/main/java/com/palmer/billingstatementgenerator/client/ApiConfig.java
+++ b/src/main/java/com/palmer/billingstatementgenerator/client/ApiConfig.java
@@ -20,6 +20,7 @@ public class ApiConfig {
     private static String baseUrl;
     private static HttpClient httpClient;
     private static String apiKey = "";
+    private static String tenantId = "";
 
     private ApiConfig() {
     }
@@ -49,6 +50,11 @@ public class ApiConfig {
         String apiKey = config.getProperty("api.key", "").trim();
         if (!apiKey.isEmpty()) {
             ApiConfig.apiKey = apiKey;
+        }
+
+        String tenantId = config.getProperty("api.tenant-id", "").trim();
+        if (!tenantId.isEmpty()) {
+            ApiConfig.tenantId = tenantId;
         }
 
         httpClient = HttpClient.newHttpClient();
@@ -82,8 +88,14 @@ public class ApiConfig {
             return HttpRequest.newBuilder(uri);
         }
 
-        return HttpRequest.newBuilder(uri)
-                .header("X-Api-Key", apiKey);
+        HttpRequest.Builder builder = HttpRequest.newBuilder(uri)
+                                                .header("X-Api-Key", apiKey);
+
+        if (!tenantId.isEmpty()) {
+            builder.header("X-Tenant-Id", tenantId);
+        }
+
+        return builder;
     }
 
     private static Properties loadConfig() {

--- a/src/main/java/com/palmer/billingstatementgenerator/views/MainView.java
+++ b/src/main/java/com/palmer/billingstatementgenerator/views/MainView.java
@@ -1,5 +1,6 @@
 package com.palmer.billingstatementgenerator.views;
 
+import atlantafx.base.theme.Styles;
 import com.palmer.billingstatementgenerator.AppInfo;
 import com.palmer.billingstatementgenerator.client.VersionClient;
 import com.palmer.billingstatementgenerator.logging.WorkflowEventTracker;
@@ -37,14 +38,20 @@ import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
+import javafx.scene.control.ContentDisplay;
 import javafx.scene.control.Label;
 import javafx.scene.control.ProgressIndicator;
 import javafx.scene.control.ScrollPane;
+import javafx.scene.control.Separator;
 import javafx.scene.control.TabPane;
+import javafx.scene.control.Toggle;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.control.ToggleGroup;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
+import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Background;
 import javafx.scene.layout.BackgroundFill;
 import javafx.scene.layout.BorderPane;
@@ -53,6 +60,7 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 import javafx.stage.Window;
@@ -61,8 +69,12 @@ import org.kordamp.ikonli.javafx.FontIcon;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 /**
@@ -76,14 +88,16 @@ public class MainView {
     private static final String FXML_BASE = "/views/";
     private final StatementService statementService = StatementService.getInstance();
     private final Label versionLabel = new Label("API Version: " + AppInfo.VERSION);
+    private final ToggleGroup stepGroup = new ToggleGroup();
+    private final List<ToggleButton> stepButtons = new ArrayList<>();
     private StackPane rootPane;
-    private BorderPane root;
+    private BorderPane billingPane;
     private TabPane tabPane;
-    private Button prevButton;
     private Button nextButton;
     private Button clearButton;
     private Button saveButton;
     private Button resetButton;
+
     /**
      * Controller for the summary tab, held for refresh and reset operations.
      */
@@ -133,7 +147,7 @@ public class MainView {
      */
     public void setEventTracker(WorkflowEventTracker eventTracker) {
         this.eventTracker = eventTracker;
-        AppDialog.configure(root.getScene().getWindow(), eventTracker);
+        AppDialog.configure(billingPane.getScene().getWindow(), eventTracker);
     }
 
     /**
@@ -173,17 +187,51 @@ public class MainView {
 
         tabPane = new TabPane(instructionsTab, serviceInformationTab, servicesTab, merchandiseTab, specialChargesTab, cashAdvanceTab, summaryTab);
         tabPane.setTabClosingPolicy(TabPane.TabClosingPolicy.UNAVAILABLE);
+        tabPane.getStyleClass().add("workflow-tabs");
+    }
+
+    private VBox buildStepNav() {
+        String[] steps = {
+                "Service Information",
+                "Services",
+                "Merchandise",
+                "Special Charges",
+                "Cash Advances",
+                "Summary"
+        };
+
+        VBox stepNav = new VBox(2);
+        stepNav.setPadding(new Insets(0, 0, 0, 8));
+
+        for (int i = 0; i < steps.length; i++) {
+            final int tabIndex = i + 1;
+            ToggleButton btn = new ToggleButton(steps[i]);
+            btn.setMaxWidth(Double.MAX_VALUE);
+            btn.setAlignment(Pos.CENTER_LEFT);
+            btn.getStyleClass().addAll("nav-btn", "step-btn");
+            btn.setOnAction(e -> tabPane.getSelectionModel().select(tabIndex));
+            btn.setToggleGroup(stepGroup);
+            btn.addEventFilter(MouseEvent.MOUSE_PRESSED, e -> {
+                if (btn.isSelected()) {
+                    e.consume();
+                }
+            });
+            stepButtons.add(btn);
+            stepNav.getChildren().add(btn);
+        }
+
+        stepButtons.getFirst().setSelected(true);
+        return stepNav;
     }
 
     /**
      * Creates the shared navigation buttons and applies their base style classes.
      */
     private void createButtonBar() {
-        prevButton = createButton("Previous", "prevButton", "");
         clearButton = createButton("Clear Selections", "clearButton", "button-clear");
         saveButton = createButton("Save", "saveButton", "button-save");
         nextButton = createButton("Next", "nextButton", "");
-        resetButton = createButton("Reset", "resetButton",  "button-reset");
+        resetButton = createButton("Reset", "resetButton", "button-reset");
         resetButton.setVisible(false);
     }
 
@@ -195,7 +243,7 @@ public class MainView {
      */
     private HBox buildButtonBar() {
         HBox rightGroup = new HBox(8, resetButton, saveButton, nextButton);
-        HBox bar = new HBox(prevButton, spacer(), clearButton, spacer(), rightGroup);
+        HBox bar = new HBox(clearButton, spacer(), rightGroup);
         bar.setPadding(new Insets(12, 24, 12, 24));
         bar.setAlignment(Pos.CENTER);
         bar.getStyleClass().add("button-bar");
@@ -213,39 +261,106 @@ public class MainView {
         return r;
     }
 
-    /**
-     * Assembles the main layout with the logo header at the top,
-     * tab pane in the center, and button bar at the bottom.
-     */
     private void createLayout() {
+        // Billing content pane (was "root")
+        billingPane = new BorderPane();
+        billingPane.setCenter(tabPane);
+        billingPane.setBottom(buildButtonBar());
+
+        // Sidebar nav
         Image logo = new Image(Objects.requireNonNull(getClass().getResourceAsStream("/img/app-icon.png")));
         ImageView logoView = new ImageView(logo);
-        logoView.setFitWidth(80);
+        logoView.setFitWidth(48);
         logoView.setPreserveRatio(true);
-        logoView.setOpacity(0.9);
 
-        Button closeBtn = createButton(new FontIcon(FontAwesomeSolid.TIMES), "closeButton", "button-close", e -> closeAppAction());
-        Button settingsBtn = createButton(new FontIcon(FontAwesomeSolid.COG), "settingsButton", "button-close", e -> new SettingsDialog().open());
-        Button feedbackBtn = createButton(new FontIcon(FontAwesomeSolid.COMMENT_ALT), "feedbackButton", "button-close", e -> openFeedbackDialogAction());
+        ToggleButton billingBtn = navToggle("Billing", new FontIcon(FontAwesomeSolid.FILE_INVOICE_DOLLAR));
+        ToggleButton licensingBtn = navToggle("Licensing", new FontIcon(FontAwesomeSolid.KEY));
 
-        Region headerSpacer = new Region();
-        HBox.setHgrow(headerSpacer, Priority.ALWAYS);
+        ToggleGroup navGroup = new ToggleGroup();
+        billingBtn.setToggleGroup(navGroup);
+        licensingBtn.setToggleGroup(navGroup);
+        billingBtn.setSelected(true);
 
-        HBox header = new HBox(logoView, headerSpacer, feedbackBtn, settingsBtn, closeBtn);
-        header.setPadding(new Insets(10, 16, 10, 16));
-        header.setAlignment(Pos.CENTER_LEFT);
-        header.getStyleClass().add("app-header");
+        Button feedbackBtn = navButton("Feedback", new FontIcon(FontAwesomeSolid.COMMENT_ALT),
+                e -> openFeedbackDialogAction());
+        Button settingsBtn = navButton("Settings", new FontIcon(FontAwesomeSolid.COG),
+                e -> new SettingsDialog().open());
 
-        root = new BorderPane();
-        root.setTop(header);
-        root.setCenter(tabPane);
-        root.setBottom(buildButtonBar());
+        Region sidebarSpacer = new Region();
+        VBox.setVgrow(sidebarSpacer, Priority.ALWAYS);
+
+        VBox stepNav = buildStepNav();
+
+        VBox sidebar = new VBox(8, logoView, new Separator(), billingBtn, stepNav, licensingBtn,
+                sidebarSpacer, feedbackBtn, settingsBtn);
+        sidebar.getStyleClass().add("sidebar");
+        sidebar.setPadding(new Insets(12, 8, 16, 8));
+        sidebar.setPrefWidth(160);
+
+        // Content area
+        BorderPane contentPane = new BorderPane(billingPane);
+
+        Map<Toggle, Runnable> navActions = Map.of(
+                billingBtn, () -> {
+                    contentPane.setCenter(billingPane);
+                    stepNav.setVisible(true);
+                    stepNav.setManaged(true);
+                    if (stepGroup.getSelectedToggle() == null) {
+                        stepButtons.getFirst().setSelected(true);
+                        tabPane.getSelectionModel().select(1);
+                    }
+                },
+                licensingBtn, () -> {
+                    contentPane.setCenter(buildLicensingStub());
+                    stepNav.setVisible(false);
+                    stepNav.setManaged(false);
+                }
+        );
+
+        navGroup.selectedToggleProperty().addListener((obs, old, selected) -> {
+            if (selected == null) {
+                old.setSelected(true);
+                return;
+            }
+            Optional.ofNullable(navActions.get(selected))
+                    .ifPresent(Runnable::run);
+        });
+
+        BorderPane mainLayout = new BorderPane();
+        mainLayout.setLeft(sidebar);
+        mainLayout.setCenter(contentPane);
 
         BorderPane outerPane = generateOuterPane();
-        outerPane.setCenter(root);
+        outerPane.setCenter(mainLayout);
 
         StackPane overlay = generateOverlay();
         rootPane = new StackPane(outerPane, overlay);
+    }
+
+    private ToggleButton navToggle(String label, FontIcon icon) {
+        ToggleButton btn = new ToggleButton(label, icon);
+        btn.setMaxWidth(Double.MAX_VALUE);
+        btn.setAlignment(Pos.CENTER_LEFT);
+        btn.setContentDisplay(ContentDisplay.LEFT);
+        btn.getStyleClass().addAll(Styles.FLAT, "nav-btn");
+        return btn;
+    }
+
+    private Button navButton(String label, FontIcon icon, EventHandler<ActionEvent> handler) {
+        Button btn = new Button(label, icon);
+        btn.setMaxWidth(Double.MAX_VALUE);
+        btn.setAlignment(Pos.CENTER_LEFT);
+        btn.setContentDisplay(ContentDisplay.LEFT);
+        btn.getStyleClass().addAll(Styles.FLAT, "nav-btn");
+        btn.setOnAction(handler);
+        return btn;
+    }
+
+    private BorderPane buildLicensingStub() {
+        Label label = new Label("Licensing — coming soon");
+        BorderPane pane = new BorderPane(label);
+        BorderPane.setAlignment(label, Pos.CENTER);
+        return pane;
     }
 
     private BorderPane generateOuterPane() {
@@ -278,7 +393,8 @@ public class MainView {
     }
 
     private Button createButton(String name, String btnId, String styleClass) {
-        Button button = createButton(null, btnId, styleClass, e -> {});
+        Button button = createButton(null, btnId, styleClass, e -> {
+        });
         button.setText(name);
         return button;
     }
@@ -294,7 +410,7 @@ public class MainView {
     }
 
     private void closeAppAction() {
-        Stage stage = (Stage) root.getScene().getWindow();
+        Stage stage = (Stage) billingPane.getScene().getWindow();
         if (StatementContext.isDirty()) {
             showUnsavedChangesOnClose(stage);
         } else {
@@ -312,10 +428,23 @@ public class MainView {
      * the selected tab changes, and sets the initial button bar state.
      */
     private void wireTabs() {
-        updateButtonBar((GeneratorTabs) tabPane.getTabs().get(0));
+        updateButtonBar((GeneratorTabs) tabPane.getTabs().getFirst());
         tabPane.getSelectionModel().selectedItemProperty().addListener((obs, oldTab, newTab) -> {
             if (newTab instanceof GeneratorTabs) {
                 updateButtonBar((GeneratorTabs) newTab);
+            }
+        });
+
+        tabPane.getSelectionModel().selectedIndexProperty().addListener((obs, old, newIdx) -> {
+            int stepIdx = newIdx.intValue() - 1;
+
+            if (stepIdx < 0) {
+                stepGroup.selectToggle(null);
+                return;
+            }
+
+            if (stepIdx < stepButtons.size()) {
+                stepButtons.get(stepIdx).setSelected(true);
             }
         });
     }
@@ -333,23 +462,14 @@ public class MainView {
         boolean isFirst = index == 0;
         boolean isLast = index == tabPane.getTabs().size() - 1;
 
-        root.setBottom(isFirst ? null : buildButtonBar());
+        billingPane.setBottom(isFirst ? null : buildButtonBar());
 
-        unbindButtonDisable(prevButton, nextButton, saveButton);
+        unbindButtonDisable(nextButton, saveButton);
 
-        prevButton.setDisable(index == 1);
         saveButton.disableProperty().bind(StatementContext.dirtyProperty().not());
         saveButton.setOnAction(e -> statementService.save(null));
 
         BooleanBinding invalid = tab.getController().hasInvalidSelections();
-
-        prevButton.setOnAction(e -> {
-            if (invalid.get()) {
-                new IncompleteAlertDialog().open();
-            } else {
-                tabPane.getSelectionModel().selectPrevious();
-            }
-        });
 
         if (isLast) {
             nextButton.setText("Generate PDF");
@@ -426,10 +546,10 @@ public class MainView {
      * to the maximum observed width and height.
      */
     public void fitWindowToLargestTab() {
-        if (root.getScene() == null) {
+        if (billingPane.getScene() == null) {
             return;
         }
-        Window window = root.getScene().getWindow();
+        Window window = billingPane.getScene().getWindow();
         if (!(window instanceof Stage stage)) {
             return;
         }
@@ -440,14 +560,15 @@ public class MainView {
 
         for (int i = 0; i < tabPane.getTabs().size(); i++) {
             tabPane.getSelectionModel().select(i);
-            root.getScene().getRoot().applyCss();
-            root.getScene().getRoot().layout();
+            billingPane.getScene().getRoot().applyCss();
+            billingPane.getScene().getRoot().layout();
             stage.sizeToScene();
             maxWidth = Math.max(maxWidth, stage.getWidth());
             maxHeight = Math.max(maxHeight, stage.getHeight());
         }
 
         tabPane.getSelectionModel().select(originalIndex);
+        stepGroup.selectToggle(null);
         stage.setMinWidth(maxWidth);
         stage.setMinHeight(maxHeight);
         stage.setWidth(maxWidth);
@@ -590,7 +711,7 @@ public class MainView {
     private void rebuildView() {
         log.info("Rebuilding view after full reset");
         createTabs();
-        root.setCenter(tabPane);
+        billingPane.setCenter(tabPane);
         wireTabs();
         wireTabDisabling();
         if (eventTracker != null) {

--- a/src/main/resources/css/style.css
+++ b/src/main/resources/css/style.css
@@ -19,6 +19,8 @@
     -sm-muted: #888888;
     -sm-border: #d0ccc7;
     -sm-bg: #f7f5f2;
+
+    -color-bg-default: -fx-background
 }
 
 /* General Text */
@@ -101,6 +103,23 @@
 
 .button:disabled {
     -fx-opacity: 0.45;
+}
+
+.nav-btn, .nav-btn:hover, .nav-btn:focused, .nav-btn:disabled {
+    -fx-background-color: transparent;
+    -fx-text-fill: -color-fg-default;
+    -fx-font-weight: normal;
+    -fx-padding: 8 12 8 12;
+}
+
+.nav-btn:hover {
+    -fx-background-color: -color-neutral-muted;
+}
+
+.nav-btn:selected {
+    -fx-background-color: -sm-navy;
+    -fx-text-fill: white;
+    -fx-background-radius: 4;
 }
 
 /* Clear button — subdued, not blue */
@@ -188,7 +207,7 @@
     -fx-border-width: 1;
     -fx-background-radius: 8;
     -fx-border-radius: 8;
-    -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.22), 18, 0, 0, 4);
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.22), 18, 0, 0, 4);
 }
 
 .dialog-header {
@@ -511,4 +530,51 @@
 .version-label {
     -fx-font-size: 9px;
     -fx-text-fill: -sm-muted
+}
+
+.sidebar {
+    -fx-background-color: -color-bg-subtle;
+    -fx-border-color: -color-border-default;
+    -fx-border-width: 0 1 0 0;
+}
+
+.workflow-tabs > .tab-header-area {
+    -fx-pref-height: 0;
+    -fx-min-height: 0;
+    -fx-max-height: 0;
+    visibility: hidden;
+}
+
+.sidebar .step-btn {
+    -fx-font-size: 12px;
+    -fx-font-weight: normal;
+    -fx-padding: 4 8 4 20;
+    -fx-text-fill: -color-fg-muted;
+    -fx-background-color: transparent;
+}
+
+.sidebar .step-btn:hover {
+    -fx-background-color: -color-neutral-muted;
+    -fx-text-fill: -color-fg-default;
+}
+
+.sidebar .step-btn:selected {
+    -fx-background-color: transparent;
+    -fx-text-fill: -sm-navy;
+    -fx-font-weight: bold;
+}
+
+.sidebar .step-btn:disabled {
+    -fx-opacity: 0.4;
+    -fx-background-color: transparent;
+}
+
+.separator > .line {
+    -fx-border-style: solid none none none;
+    -fx-border-color: -color-border-default;
+    -fx-background-color: transparent;
+}
+
+.separator {
+    -fx-background-color: transparent;
 }


### PR DESCRIPTION
## Commits

- **Update build.gradle to reflect re-branding**
- **Implement AtlantaFX redesign with side navigation (#21)**

## Summary

- Applies AtlantaFX PrimerLight theme as the design system baseline
- Replaces the horizontal tab bar with a collapsible side navigation rail (Billing, Licensing), with workflow step sub-nav (Service Info → Summary) under Billing
- Removes the Previous button — sidebar navigation handles backwards traversal
- Rebrands jpackage app name and vendor from "Statement Manager" to "Eternatel"
- Adds X-Tenant-Id header support to ApiConfig for local dev tenant wiring

## Issues Filed During This Work 

- #22 — Services tab: "Other" items auto-selected on initialization
- #23 — Billing home screen: replace Instructions tab with dashboard
- #24 — Refactor MainView.java: extract AppSidebar and BillingWorkflowPane
