### PR TITLE
Desktop app license key authentication

### DIFF
--- a/src/main/java/com/palmer/billingstatementgenerator/MainApp.java
+++ b/src/main/java/com/palmer/billingstatementgenerator/MainApp.java
@@ -10,6 +10,8 @@ import com.palmer.billingstatementgenerator.util.AppLock;
 import com.palmer.billingstatementgenerator.util.AppPreferences;
 import com.palmer.billingstatementgenerator.views.MainView;
 import com.palmer.billingstatementgenerator.views.SplashView;
+import com.palmer.billingstatementgenerator.views.dialogs.AppDialog;
+import com.palmer.billingstatementgenerator.views.dialogs.LicenseKeyDialog;
 import com.palmer.billingstatementgenerator.views.dialogs.MessageDialog;
 import javafx.animation.Interpolator;
 import javafx.animation.KeyFrame;
@@ -66,6 +68,18 @@ public class MainApp extends Application {
         primaryStage.setScene(splashScene);
         primaryStage.initStyle(StageStyle.UNDECORATED);
         primaryStage.show();
+
+        String licenseKey = AppPreferences.getLicenseKey();
+        if (licenseKey == null || licenseKey.isBlank()) {
+            AppDialog.configure(primaryStage, null);
+            String entered = new LicenseKeyDialog().open();
+
+            if (entered == null) {
+                Platform.exit();
+                return;
+            }
+            AppPreferences.setLicenseKey(entered);
+        }
 
         Task<Void> initTask = new Task<>() {
             @Override

--- a/src/main/java/com/palmer/billingstatementgenerator/client/ApiConfig.java
+++ b/src/main/java/com/palmer/billingstatementgenerator/client/ApiConfig.java
@@ -1,5 +1,6 @@
 package com.palmer.billingstatementgenerator.client;
 
+import com.palmer.billingstatementgenerator.util.AppPreferences;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,18 +85,22 @@ public class ApiConfig {
     }
 
     public static HttpRequest.Builder authenticatedRequest(URI uri) {
-        if (apiKey.isEmpty()) {
-            return HttpRequest.newBuilder(uri);
+        String licenseKey = AppPreferences.getLicenseKey();
+        HttpRequest.Builder builder = HttpRequest.newBuilder(uri);
+
+        if (licenseKey != null && !licenseKey.isBlank()) {
+            return builder.header("X-License-Key", licenseKey);
         }
 
-        HttpRequest.Builder builder = HttpRequest.newBuilder(uri)
-                                                .header("X-Api-Key", apiKey);
+        if (apiKey.isEmpty()) {
+            return builder;
+        }
 
         if (!tenantId.isEmpty()) {
             builder.header("X-Tenant-Id", tenantId);
         }
 
-        return builder;
+        return builder.header("X-Api-Key", apiKey);
     }
 
     private static Properties loadConfig() {

--- a/src/main/java/com/palmer/billingstatementgenerator/client/StatementClient.java
+++ b/src/main/java/com/palmer/billingstatementgenerator/client/StatementClient.java
@@ -40,7 +40,13 @@ public class StatementClient {
         try {
             HttpResponse<String> response = getResponse("/next-control-number");
 
-            return Integer.parseInt(response.body().trim());
+            String nextControlNumberString = response.body().trim();
+
+            if (nextControlNumberString.isEmpty()) {
+                return 1001;
+            }
+
+            return Integer.parseInt(nextControlNumberString);
 
         } catch (Exception e) {
             log.error("Failed to get next control number", e);

--- a/src/main/java/com/palmer/billingstatementgenerator/util/AppPreferences.java
+++ b/src/main/java/com/palmer/billingstatementgenerator/util/AppPreferences.java
@@ -1,6 +1,10 @@
 package com.palmer.billingstatementgenerator.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.math.BigDecimal;
+import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 
 /**
@@ -15,10 +19,12 @@ import java.util.prefs.Preferences;
  * </ul>
  */
 public final class AppPreferences {
+    private static final Logger logger = LoggerFactory.getLogger(AppPreferences.class);
 
     private static final String NODE_PATH = "com/palmer/billingstatementgenerator";
     private static final String KEY_TAX_RATE = "salesTaxRate";
     private static final String KEY_HAS_LAUNCHED = "hasLaunched";
+    private static final String KEY_LICENSE_KEY = "licenseKey";
 
     private AppPreferences() {
     }
@@ -70,5 +76,28 @@ public final class AppPreferences {
      */
     public static void setHasLaunched(boolean value) {
         node().putBoolean(KEY_HAS_LAUNCHED, value);
+    }
+
+    public static String getLicenseKey() {
+        return node().get(KEY_LICENSE_KEY, null);
+    }
+
+    public static void setLicenseKey(String licenseKey) {
+        node().put(KEY_LICENSE_KEY, licenseKey);
+
+        try {
+            node().flush();
+        } catch (BackingStoreException e) {
+            logger.warn("Failed to flush license key to preferences store", e);
+        }
+    }
+
+    public static void removeLicenseKey() {
+        node().remove(KEY_LICENSE_KEY);
+        try {
+            node().flush();
+        } catch (java.util.prefs.BackingStoreException e) {
+            logger.warn("Failed to flush license key removal", e);
+        }
     }
 }

--- a/src/main/java/com/palmer/billingstatementgenerator/views/MainView.java
+++ b/src/main/java/com/palmer/billingstatementgenerator/views/MainView.java
@@ -9,6 +9,7 @@ import com.palmer.billingstatementgenerator.models.statement.StatementCalculator
 import com.palmer.billingstatementgenerator.models.statement.StatementContext;
 import com.palmer.billingstatementgenerator.services.PdfService;
 import com.palmer.billingstatementgenerator.services.StatementService;
+import com.palmer.billingstatementgenerator.util.AppPreferences;
 import com.palmer.billingstatementgenerator.views.controllers.BaseController;
 import com.palmer.billingstatementgenerator.views.controllers.CashAdvanceController;
 import com.palmer.billingstatementgenerator.views.controllers.InstructionsTabController;
@@ -86,10 +87,16 @@ import java.util.function.Consumer;
 public class MainView {
     private static final Logger log = LoggerFactory.getLogger(MainView.class);
     private static final String FXML_BASE = "/views/";
+    private static final List<KeyCode> RESET_SEQUENCE = List.of(
+            KeyCode.UP, KeyCode.UP, KeyCode.DOWN, KeyCode.DOWN,
+            KeyCode.LEFT, KeyCode.RIGHT, KeyCode.LEFT, KeyCode.RIGHT,
+            KeyCode.E
+    );
     private final StatementService statementService = StatementService.getInstance();
     private final Label versionLabel = new Label("API Version: " + AppInfo.VERSION);
     private final ToggleGroup stepGroup = new ToggleGroup();
     private final List<ToggleButton> stepButtons = new ArrayList<>();
+    private final List<KeyCode> keyBuffer = new ArrayList<>();
     private StackPane rootPane;
     private BorderPane billingPane;
     private TabPane tabPane;
@@ -97,7 +104,6 @@ public class MainView {
     private Button clearButton;
     private Button saveButton;
     private Button resetButton;
-
     /**
      * Controller for the summary tab, held for refresh and reset operations.
      */
@@ -536,6 +542,22 @@ public class MainView {
                     openFeedbackDialogAction();
                     e.consume();
                 }
+            }
+        });
+
+        scene.addEventFilter(KeyEvent.KEY_PRESSED, e -> {
+            keyBuffer.add(e.getCode());
+            if (keyBuffer.size() > RESET_SEQUENCE.size()) {
+                keyBuffer.removeFirst();
+            }
+            if (keyBuffer.equals(RESET_SEQUENCE)) {
+                keyBuffer.clear();
+                AppPreferences.removeLicenseKey();
+                new MessageDialog("License Key Cleared",
+                        """
+                                License key has been cleared.
+                                Restart the app to re-activate.
+                                """).open();
             }
         });
     }

--- a/src/main/java/com/palmer/billingstatementgenerator/views/dialogs/AppDialog.java
+++ b/src/main/java/com/palmer/billingstatementgenerator/views/dialogs/AppDialog.java
@@ -134,4 +134,12 @@ public abstract class AppDialog<R> extends Stage {
         showAndWait();
         return result;
     }
+
+    protected Label buildErrorLabel(String labelText) {
+        Label errorLabel = new Label(labelText);
+        errorLabel.getStyleClass().add("splash-subtitle");
+        errorLabel.setVisible(false);
+
+        return errorLabel;
+    }
 }

--- a/src/main/java/com/palmer/billingstatementgenerator/views/dialogs/LicenseKeyDialog.java
+++ b/src/main/java/com/palmer/billingstatementgenerator/views/dialogs/LicenseKeyDialog.java
@@ -1,0 +1,74 @@
+package com.palmer.billingstatementgenerator.views.dialogs;
+
+import javafx.geometry.Pos;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+import javafx.scene.text.TextAlignment;
+
+public class LicenseKeyDialog extends AppDialog<String> {
+
+    private TextField keyField;
+    private Label errorLabel;
+
+    @Override
+    protected VBox buildContent() {
+        Label instructionLabel = buildInstructionLabel();
+        keyField = buildKeyTextField();
+        errorLabel = buildErrorLabel("Invalid license key format");
+        Button activateButton = buildActivateButton();
+        Button cancelButton = buildCancelButton();
+
+        HBox buttons = new HBox(12, activateButton, cancelButton);
+        buttons.setAlignment(Pos.CENTER);
+
+        return contentBox("Activate Desktop App", instructionLabel, keyField, errorLabel, buttons);
+    }
+
+    private Label buildInstructionLabel() {
+        Label instructions = new Label("""
+                                      Enter the license key from your Eternatel web portal
+                                      Settings page to activate the desktop app.
+                                      """);
+        instructions.getStyleClass().add("splash-subtitle");
+        instructions.setTextAlignment(TextAlignment.CENTER);
+        return instructions;
+    }
+
+    private TextField buildKeyTextField() {
+        TextField keyField = new TextField();
+        keyField.setPromptText("EDC-XXXXX-XXXXX-XXXXX-XXXXX");
+        keyField.setMaxWidth(280);
+        keyField.setId("licenseKeyField");
+
+        return keyField;
+    }
+
+    private Button buildActivateButton() {
+        Button button = new Button("Activate");
+        button.setId("activateButton");
+        button.setOnAction(event -> {
+            String key = keyField.getText().trim().toUpperCase();
+
+            if (key.matches("EDC(-[A-Z2-9]{4}){5}")) {
+                result = key;
+                close();
+            } else {
+                errorLabel.setVisible(true);
+            }
+        });
+
+        return button;
+    }
+
+    private Button buildCancelButton() {
+        Button button = new Button("Cancel");
+        button.setId("cancelButton");
+        button.getStyleClass().add("button-clear");
+        button.setOnAction(event -> close());
+
+        return button;
+    }
+}

--- a/src/main/java/com/palmer/billingstatementgenerator/views/dialogs/SettingsDialog.java
+++ b/src/main/java/com/palmer/billingstatementgenerator/views/dialogs/SettingsDialog.java
@@ -30,24 +30,14 @@ public class SettingsDialog extends AppDialog<Void> {
 
         String displayRate = AppPreferences.getSalesTaxRate()
                 .movePointRight(2).stripTrailingZeros().toPlainString();
-        TextField taxRateField = new TextField(displayRate);
-        taxRateField.setMaxWidth(100);
-        taxRateField.setId("taxRateField");
 
-        Label taxRateError = new Label("Please enter a valid number (e.g. 8.25)");
-        taxRateError.getStyleClass().add("splash-subtitle");
-        taxRateError.setVisible(false);
+        TextField taxRateField = buildTaxRateField(displayRate);
+        Label taxRateError = buildErrorLabel("Please enter a valid number (e.g. 8.25)");
 
         HBox taxRateRow = new HBox(12, taxRateLabel, taxRateField);
         taxRateRow.setAlignment(Pos.CENTER);
 
-        Button resetPromptsButton = new Button("Reset Help Prompts");
-        resetPromptsButton.setId("resetPromptsButton");
-        resetPromptsButton.setOnAction(e -> {
-            AppPreferences.setHasLaunched(false);
-            resetPromptsButton.setText("✓ Takes effect on next launch");
-            resetPromptsButton.setDisable(true);
-        });
+        Button resetPromptsButton = buildResetPromptButton();
 
         Label resetNote = new Label("Shows the instructions tab on next launch");
         resetNote.getStyleClass().add("splash-subtitle");
@@ -55,6 +45,42 @@ public class SettingsDialog extends AppDialog<Void> {
         VBox resetSection = new VBox(6, resetPromptsButton, resetNote);
         resetSection.setAlignment(Pos.CENTER);
 
+        Button saveBtn = buildSaveButton(taxRateField, taxRateError);
+        Button cancelButton = buildCancelButton();
+
+        HBox buttons = new HBox(12, saveBtn, cancelButton);
+        buttons.setAlignment(Pos.CENTER);
+
+        return contentBox("Settings", taxRateRow, taxRateError, resetSection, buttons);
+    }
+
+    private TextField buildTaxRateField(String displayRate) {
+        TextField taxRateField = new TextField(displayRate);
+        taxRateField.setMaxWidth(100);
+        taxRateField.setId("taxRateField");
+        return taxRateField;
+    }
+
+    private Button buildResetPromptButton() {
+        Button resetPromptsButton = new Button("Reset Help Prompts");
+        resetPromptsButton.setId("resetPromptsButton");
+        resetPromptsButton.setOnAction(e -> {
+            AppPreferences.setHasLaunched(false);
+            resetPromptsButton.setText("✓ Takes effect on next launch");
+            resetPromptsButton.setDisable(true);
+        });
+        return resetPromptsButton;
+    }
+
+    private Button buildCancelButton() {
+        Button cancelButton = new Button("Cancel");
+        cancelButton.setId("settingsCancelButton");
+        cancelButton.getStyleClass().add("button-clear");
+        cancelButton.setOnAction(e -> close());
+        return cancelButton;
+    }
+
+    private Button buildSaveButton(TextField taxRateField, Label taxRateError) {
         Button saveBtn = new Button("Save");
         saveBtn.setId("settingsSaveButton");
         saveBtn.setOnAction(e -> {
@@ -68,15 +94,6 @@ public class SettingsDialog extends AppDialog<Void> {
                 taxRateError.setVisible(true);
             }
         });
-
-        Button cancelButton = new Button("Cancel");
-        cancelButton.setId("settingsCancelButton");
-        cancelButton.getStyleClass().add("button-clear");
-        cancelButton.setOnAction(e -> close());
-
-        HBox buttons = new HBox(12, saveBtn, cancelButton);
-        buttons.setAlignment(Pos.CENTER);
-
-        return contentBox("Settings", taxRateRow, taxRateError, resetSection, buttons);
+        return saveBtn;
     }
 }


### PR DESCRIPTION
## Summary

- Shows `LicenseKeyDialog` at startup if no key is stored, blocking launch until a valid `EDC-XXXXX-XXXXX-XXXXX-XXXXX` key is entered
- Key is persisted to OS preferences (Registry on Windows, plist on macOS) and sent as `X-License-Key` on all API requests, with dev fallback to `X-Api-Key`
- Adds Konami-code cheat sequence to clear the stored key for re-activation
- Handles empty control number response from a fresh tenant

Closes #20