### PR TITLE
Per-tenant settings — fetch sales tax rate from API (#71)

### DIFF
--- a/src/main/java/com/palmer/billingstatementgenerator/client/SettingsClient.java
+++ b/src/main/java/com/palmer/billingstatementgenerator/client/SettingsClient.java
@@ -1,0 +1,58 @@
+package com.palmer.billingstatementgenerator.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.palmer.billingstatementgenerator.models.TenantSettings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+public class SettingsClient {
+    private static final Logger log = LoggerFactory.getLogger(SettingsClient.class);
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private final HttpResponse.BodyHandler<String> responseBodyHandler = HttpResponse.BodyHandlers.ofString();
+    ;
+
+    public TenantSettings getSettings() {
+        try {
+            HttpRequest request = ApiConfig.authenticatedRequest(URI.create(ApiConfig.getBaseUrl() + "/settings"))
+                                           .GET()
+                                           .build();
+
+            HttpResponse<String> response = ApiConfig.getHttpClient().send(request, responseBodyHandler);
+
+            JsonNode node = mapper.readTree(response.body());
+
+            return new TenantSettings()
+                    .setSalesTaxRate(node.get("salesTaxRate").decimalValue());
+        } catch (Exception e) {
+            log.error("Failed to load settings", e);
+            throw new RuntimeException("Failed to load settings", e);
+        }
+    }
+
+    public void updateSettings(TenantSettings settings) {
+        try {
+            ObjectNode node = mapper.createObjectNode();
+
+            if (settings.getSalesTaxRate() != null) {
+                node.put("salesTaxRate", settings.getSalesTaxRate());
+            }
+
+            HttpRequest request = ApiConfig.authenticatedRequest(URI.create(ApiConfig.getBaseUrl() + "/settings"))
+                                           .header("Content-Type", "application/json")
+                                           .PUT(HttpRequest.BodyPublishers.ofString(node.toString()))
+                                           .build();
+
+            ApiConfig.getHttpClient().send(request, responseBodyHandler);
+        } catch (Exception e) {
+            log.error("Failed to update settings", e);
+            throw new RuntimeException("Failed to update settings", e);
+        }
+    }
+}

--- a/src/main/java/com/palmer/billingstatementgenerator/models/TenantSettings.java
+++ b/src/main/java/com/palmer/billingstatementgenerator/models/TenantSettings.java
@@ -1,0 +1,17 @@
+package com.palmer.billingstatementgenerator.models;
+
+import java.math.BigDecimal;
+
+public class TenantSettings {
+
+    private BigDecimal salesTaxRate;
+
+    public TenantSettings setSalesTaxRate(BigDecimal salesTaxRate) {
+        this.salesTaxRate = salesTaxRate;
+        return this;
+    }
+
+    public BigDecimal getSalesTaxRate() {
+        return salesTaxRate;
+    }
+}

--- a/src/main/java/com/palmer/billingstatementgenerator/models/statement/StatementContext.java
+++ b/src/main/java/com/palmer/billingstatementgenerator/models/statement/StatementContext.java
@@ -1,6 +1,7 @@
 package com.palmer.billingstatementgenerator.models.statement;
 
 import com.palmer.billingstatementgenerator.client.CatalogClient;
+import com.palmer.billingstatementgenerator.client.SettingsClient;
 import com.palmer.billingstatementgenerator.client.StatementClient;
 import com.palmer.billingstatementgenerator.models.catalog.ServicePackage;
 import com.palmer.billingstatementgenerator.models.lineitems.CashAdvanceLineItem;
@@ -29,9 +30,10 @@ public final class StatementContext {
 
     private static final Logger log = LoggerFactory.getLogger(StatementContext.class);
     private static final BooleanProperty dirty = new SimpleBooleanProperty(false);
+    private static final CatalogClient catalogClient = new CatalogClient();
+    private static final SettingsClient settingsClient = new SettingsClient();
     private static Statement current;
     private static Integer savedId;
-    private static final CatalogClient catalogClient = new CatalogClient();
 
     private StatementContext() {
     }
@@ -70,9 +72,9 @@ public final class StatementContext {
         int packageId = new StatementClient().load(id, statement);
         if (packageId > 0) {
             ServicePackage pkg = catalogClient.findAllServicePackages().stream()
-                    .filter(p -> p.id() == packageId)
-                    .findFirst()
-                    .orElse(null);
+                                              .filter(p -> p.id() == packageId)
+                                              .findFirst()
+                                              .orElse(null);
             statement.setSelectedPackage(pkg);
         }
         current = statement;
@@ -138,15 +140,15 @@ public final class StatementContext {
 
     private static Statement buildFreshStatement() {
         Statement statement = new Statement();
-        statement.setSalesTaxRate(AppPreferences.getSalesTaxRate());
+        statement.setSalesTaxRate(settingsClient.getSettings().getSalesTaxRate());
         catalogClient.findAllServices()
-                .forEach(s -> statement.getServices().add(new ServiceLineItem(s)));
+                     .forEach(s -> statement.getServices().add(new ServiceLineItem(s)));
         catalogClient.findAllMerchandise()
-                .forEach(m -> statement.getMerchandise().add(new MerchandiseLineItem(m)));
+                     .forEach(m -> statement.getMerchandise().add(new MerchandiseLineItem(m)));
         catalogClient.findAllSpecialCharges()
-                .forEach(sc -> statement.getSpecialCharges().add(new SpecialChargeLineItem(sc)));
+                     .forEach(sc -> statement.getSpecialCharges().add(new SpecialChargeLineItem(sc)));
         catalogClient.findAllCashAdvances()
-                .forEach(ca -> statement.getCashAdvances().add(new CashAdvanceLineItem(ca)));
+                     .forEach(ca -> statement.getCashAdvances().add(new CashAdvanceLineItem(ca)));
         return statement;
     }
 

--- a/src/main/java/com/palmer/billingstatementgenerator/util/AppPreferences.java
+++ b/src/main/java/com/palmer/billingstatementgenerator/util/AppPreferences.java
@@ -3,7 +3,6 @@ package com.palmer.billingstatementgenerator.util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.math.BigDecimal;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 
@@ -14,7 +13,6 @@ import java.util.prefs.Preferences;
  *
  * <p>Keys managed here:
  * <ul>
- *   <li>{@code salesTaxRate} — decimal tax rate (e.g. {@code 0.0825} for 8.25%)</li>
  *   <li>{@code hasLaunched} — whether the app has completed at least one launch</li>
  * </ul>
  */
@@ -22,7 +20,6 @@ public final class AppPreferences {
     private static final Logger logger = LoggerFactory.getLogger(AppPreferences.class);
 
     private static final String NODE_PATH = "com/palmer/billingstatementgenerator";
-    private static final String KEY_TAX_RATE = "salesTaxRate";
     private static final String KEY_HAS_LAUNCHED = "hasLaunched";
     private static final String KEY_LICENSE_KEY = "licenseKey";
 
@@ -31,31 +28,6 @@ public final class AppPreferences {
 
     private static Preferences node() {
         return Preferences.userRoot().node(NODE_PATH);
-    }
-
-    /**
-     * Returns the configured sales tax rate.
-     * Defaults to {@code 0.00} if not set or if the stored value cannot be parsed.
-     *
-     * @return the tax rate as a decimal (e.g. {@code 0.0825} for 8.25%)
-     */
-    public static BigDecimal getSalesTaxRate() {
-        String val = node().get(KEY_TAX_RATE, "0.00");
-        try {
-            return new BigDecimal(val);
-        } catch (NumberFormatException e) {
-            return BigDecimal.ZERO;
-        }
-    }
-
-    /**
-     * Persists the sales tax rate.
-     *
-     * @param rate
-     *         the tax rate as a decimal (e.g. {@code 0.0825} for 8.25%)
-     */
-    public static void setSalesTaxRate(BigDecimal rate) {
-        node().put(KEY_TAX_RATE, rate.toPlainString());
     }
 
     /**

--- a/src/main/java/com/palmer/billingstatementgenerator/views/dialogs/SettingsDialog.java
+++ b/src/main/java/com/palmer/billingstatementgenerator/views/dialogs/SettingsDialog.java
@@ -1,5 +1,7 @@
 package com.palmer.billingstatementgenerator.views.dialogs;
 
+import com.palmer.billingstatementgenerator.client.SettingsClient;
+import com.palmer.billingstatementgenerator.models.TenantSettings;
 import com.palmer.billingstatementgenerator.models.statement.StatementContext;
 import com.palmer.billingstatementgenerator.util.AppPreferences;
 import javafx.geometry.Pos;
@@ -19,6 +21,7 @@ import java.math.BigDecimal;
 public class SettingsDialog extends AppDialog<Void> {
 
     private static final Logger log = LoggerFactory.getLogger(SettingsDialog.class);
+    private static final SettingsClient settingsClient = new SettingsClient();
 
     /**
      * {@inheritDoc}
@@ -28,7 +31,7 @@ public class SettingsDialog extends AppDialog<Void> {
         Label taxRateLabel = new Label("Sales Tax Rate (%)");
         taxRateLabel.getStyleClass().add("splash-subtitle");
 
-        String displayRate = AppPreferences.getSalesTaxRate()
+        String displayRate = settingsClient.getSettings().getSalesTaxRate()
                 .movePointRight(2).stripTrailingZeros().toPlainString();
 
         TextField taxRateField = buildTaxRateField(displayRate);
@@ -86,7 +89,7 @@ public class SettingsDialog extends AppDialog<Void> {
         saveBtn.setOnAction(e -> {
             try {
                 BigDecimal rate = new BigDecimal(taxRateField.getText().trim()).movePointLeft(2);
-                AppPreferences.setSalesTaxRate(rate);
+                settingsClient.updateSettings(new TenantSettings().setSalesTaxRate(rate));
                 StatementContext.current().setSalesTaxRate(rate);
                 log.info("Tax rate updated to {}", rate.toPlainString());
                 close();


### PR DESCRIPTION
## Summary
- Add `SettingsClient` for GET/PUT `/settings`
- Add `TenantSettings` fluent POJO to carry settings fields across the client layer
- `StatementContext` now fetches the sales tax rate from the API on statement init instead of reading from local preferences
- `SettingsDialog` reads the current rate from the API on open and saves changes via PUT
- Remove `salesTaxRate` from `AppPreferences` — no longer stored locally